### PR TITLE
Fix NPR One selectors.

### DIFF
--- a/code/js/controllers/NprController.js
+++ b/code/js/controllers/NprController.js
@@ -3,10 +3,10 @@
 
   require("BaseController").init({
     siteName: "NPR",
-    playPause: ".play.jp-play",
-    play: ".play.jp-play",
-    pause: ".pause.jp-pause",
-    playNext: ".sprite-next",
+    playPause: "a.play",
+    play: "a.play",
+    pause: "a.pause",
+    playNext: "a.next",
 
     song: ".title"
   });


### PR DESCRIPTION
The play and pause selectors no longer have jp-play and jp-pause. I think using the anchor with the generic class might be more robust going forward.
